### PR TITLE
Check for errors in the response from Vault

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -54,7 +54,7 @@ function request_cert() {
          \"ip_sans\": \"${IP_SAN},127.0.0.1\", \
          \"alt_names\": \"${ALT_NAMES}\"}" \
     > response.json
-  if [[ $? != 0 ]]; then
+  if [[ $? != 0 ]] || [[ "true" -eq "$(jq 'has("errors")' -r < response.json)" ]]; then
     echo 'Unable to fetch a certificate.'
     cat response.json
     exit 1

--- a/run.sh
+++ b/run.sh
@@ -54,7 +54,7 @@ function request_cert() {
          \"ip_sans\": \"${IP_SAN},127.0.0.1\", \
          \"alt_names\": \"${ALT_NAMES}\"}" \
     > response.json
-  if [[ $? != 0 ]] || [[ "true" -eq "$(jq 'has("errors")' -r < response.json)" ]]; then
+  if [[ $? != 0 ]] || [[ "true" == "$(jq 'has("errors")' -r < response.json)" ]]; then
     echo 'Unable to fetch a certificate.'
     cat response.json
     exit 1


### PR DESCRIPTION
Without this error checking it's much less obvious what's wrong. You get messages like:

```
Creating a JAVA truststore as truststore.jks.
keytool error: java.lang.Exception: Input not an X.509 certificate
Creating a temporary pkcs12 keystore.
unable to load private key
139776327989152:error:0906D06C:PEM routines:PEM_read_bio:no start line:pem_lib.c:703:Expecting: ANY PRIVATE KEY
Creating a JAVA keystore as /keystore/keystore.jks.
keytool error: java.lang.Exception: Source keystore file exists, but is empty: keystore.p12
keytool error: java.lang.Exception: Keystore file does not exist: /keystore/keystore.jks
```

After the change, the output looks like:

```
Fetching CA certificate.
Requesting a certificate.
Unable to fetch a certificate.
{"errors":["permission denied"]}
```

Tested with my own image containing this change: `devth/vaultjks:check.error`